### PR TITLE
[39] bugfix updates from background dialog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,11 @@
+---
+name: Default issue template
+about: Default issue template
+---
+### Issue link:
+
+### Description:
+
+#### Solution:
+
+### Screenshots

--- a/applvsdklib/src/main/java/com/applivery/applvsdklib/ui/views/update/SuggestedUpdateViewImpl.java
+++ b/applvsdklib/src/main/java/com/applivery/applvsdklib/ui/views/update/SuggestedUpdateViewImpl.java
@@ -35,7 +35,7 @@ import com.applivery.applvsdklib.ui.model.UpdateInfo;
  * Created by Sergio Martinez Rodriguez
  * Date 3/1/16.
  */
-public class SuggestedUpdateViewImpl implements UpdateView {
+public class SuggestedUpdateViewImpl implements UpdateView, DialogInterface.OnDismissListener {
 
   private final Builder builder;
   private final AlertDialog alertDialog;
@@ -77,7 +77,8 @@ public class SuggestedUpdateViewImpl implements UpdateView {
     builder.setTitle(updateInfo.getAppName())
         .setCancelable(true)
         .setPositiveButton(context.getString(R.string.appliveryUpdate), onUpdateClick())
-        .setNegativeButton(context.getString(R.string.appliveryLater), onCancelClick());
+        .setNegativeButton(context.getString(R.string.appliveryLater), onCancelClick())
+        .setOnDismissListener(this);
     return builder;
   }
 
@@ -85,7 +86,6 @@ public class SuggestedUpdateViewImpl implements UpdateView {
     return new DialogInterface.OnClickListener() {
       @Override public void onClick(DialogInterface dialog, int id) {
         updateListener.onUpdateButtonClick();
-        isVisible = false;
         alertDialog.dismiss();
       }
     };
@@ -94,10 +94,13 @@ public class SuggestedUpdateViewImpl implements UpdateView {
   private DialogInterface.OnClickListener onCancelClick() {
     return new DialogInterface.OnClickListener() {
       @Override public void onClick(DialogInterface dialog, int id) {
-        isVisible = false;
         alertDialog.dismiss();
       }
     };
+  }
+
+  @Override public void onDismiss(DialogInterface dialogInterface) {
+    isVisible = false;
   }
 
   @Override public void showUpdateDialog() {

--- a/sample/src/main/java/com/applivery/sample/MainActivity.kt
+++ b/sample/src/main/java/com/applivery/sample/MainActivity.kt
@@ -6,6 +6,7 @@ import android.view.Menu
 import android.view.MenuItem
 import com.applivery.applvsdklib.Applivery
 import kotlinx.android.synthetic.main.activity_main.checkForUpdatesBackgroundSwitch
+import kotlinx.android.synthetic.main.activity_main.checkForUpdatesButton
 import kotlinx.android.synthetic.main.activity_main.chronometer
 import kotlinx.android.synthetic.main.activity_main.feedbackSwitch
 import kotlinx.android.synthetic.main.activity_main.screenshotSwitch
@@ -49,6 +50,10 @@ class MainActivity : AppCompatActivity() {
       } else {
         Applivery.disableScreenshotFeedback()
       }
+    }
+
+    checkForUpdatesButton.setOnClickListener {
+      Applivery.checkForUpdates()
     }
   }
 

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -145,6 +145,20 @@
       <View
           android:layout_width="match_parent"
           android:layout_height="1dp"
+          android:layout_marginBottom="@dimen/spacing_normal"
+          android:layout_marginTop="@dimen/spacing_normal"
+          android:background="@color/secondary_text"
+          />
+
+      <Button
+          android:id="@+id/checkForUpdatesButton"
+          android:layout_width="match_parent"
+          android:text="@string/main_view_check_for_updates"
+          android:layout_height="wrap_content"/>
+
+      <View
+          android:layout_width="match_parent"
+          android:layout_height="1dp"
           android:layout_marginTop="@dimen/spacing_normal"
           android:background="@color/secondary_text"
           />

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
   <string name="check_for_updates_background">Check for updates background</string>
   <string name="enable_shake_feedback">Enable shake feedback</string>
   <string name="enable_screenshot_feedback">Enable screenshot feedback</string>
+  <string name="main_view_check_for_updates">Check for updates</string>
   <string name="show_user">Show user</string>
   <string name="bind_user">Bind user</string>
   <string name="unbind_user">Unbind user</string>


### PR DESCRIPTION
### Issue link:
https://github.com/applivery/applivery-android-sdk/issues/39

### Description:
The flag `isVisible` in `SuggestedUpdateViewImpl` is not getting update if the user close the dialog by clicking outside of it. This behaviour prevents to show the dialog again when the SDK try to show it

#### Solution:
Update the flag when the dialog is dismissed

### Screenshots
| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/7646370/64693615-8b0fef80-d48f-11e9-866e-2775c1387da9.gif) | ![after](https://user-images.githubusercontent.com/7646370/64693295-d8d82800-d48e-11e9-8922-ed68ccd7f16e.gif) |