### PR TITLE
Change 'implementation' to 'api'

### DIFF
--- a/applvsdklib/build.gradle
+++ b/applvsdklib/build.gradle
@@ -77,8 +77,8 @@ dependencies {
 
     implementation "com.karumi:dexter:${dexterVersion}"
 
-    api(project(":applivery-base"))
-    api(project(":applivery-updates"))
+    implementation(project(":applivery-base"))
+    implementation(project(":applivery-updates"))
 
     // Test dependencies
     testImplementation "junit:junit:${junitVersion}"


### PR DESCRIPTION
All dependencies in those two modules are imported in app dependencies.
@manuelrebollobaez, you are using alpha version of one library and force to update the version of this library in the main app.
https://medium.com/mindorks/implementation-vs-api-in-gradle-3-0-494c817a6fa

Best regards.
:-D