### PR TITLE
Reduce required min sdk version

### DIFF
--- a/applivery-base/build.gradle
+++ b/applivery-base/build.gradle
@@ -26,7 +26,7 @@ android {
     buildToolsVersion "29.0.2"
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 15
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/applivery-updates/build.gradle
+++ b/applivery-updates/build.gradle
@@ -28,7 +28,7 @@ android {
     buildToolsVersion "29.0.2"
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 15
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ subprojects { project ->
 
     ext {
         versions = [
-                minSdk    : 21,
+                minSdk    : 15,
                 targetSdk : 28,
                 compileSdk: 28,
         ]


### PR DESCRIPTION
### Description:
With this PR I kindly ask to reduce the minimum android SDK version needed to run the Applivery SDK. 

This is due to the fact that, (sadly) a lot of our customers still use android 4.4 and we would like to keep shipping updates to them through Applivery with the original SDK. Thanks in advance if you decide to approve and merge this.
