### PR TITLE
Disable Jetifier

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -21,7 +21,7 @@ ext {
     loggingInterceptorVersion = "3.11.0"
     gsonVersion = "2.8.5"
 
-    dexterVersion = "5.0.0"
+    dexterVersion = "6.2.1"
 
     junitVersion = "4.12"
     mockitoVersion = "2.0.2-beta"

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,5 @@ org.gradle.jvmargs=-Xmx1536m
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official


### PR DESCRIPTION
I want to disable Jetifier on my project but you still have a dependency using the support.

Dexter migrate to androidX on their 6.0.0 release: https://github.com/Karumi/Dexter/releases/tag/6.0.0

Thanks!